### PR TITLE
Fix translator container networking by routing NodeBB translation req…

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -4,8 +4,12 @@ services:
   nodebb:
     user: "0"
     build: .
-    # image: ghcr.io/nodebb/nodebb:latest
     restart: unless-stopped
+    environment:
+      - START_BUILD=true
+      - TRANSLATOR_API=http://host.docker.internal:5000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - '4567:4567' # comment this out if you don't want to expose NodeBB to the host, or change the first number to any port you want
     volumes:

--- a/src/translate/index.js
+++ b/src/translate/index.js
@@ -4,7 +4,7 @@
 const translatorApi = module.exports;
 
 translatorApi.translate = async function (postData) {
-	const TRANSLATOR_API = 'http://localhost:5000';
+	const TRANSLATOR_API = 'http://172.17.0.1:5000';
 	try {
 		const response = await fetch(TRANSLATOR_API + '/?content=' + encodeURIComponent(postData.content));
 		const data = await response.json();


### PR DESCRIPTION
This PR fixes a Docker networking issue that prevented the NodeBB container from reaching the translation service running on the host VM.

**Root cause**
The translation endpoint was configured as `http://localhost:5000`, but inside Docker, `localhost` refers to the NodeBB container itself, not the host machine. As a result, translation requests failed, posts were saved with the fallback path, and non-English posts were incorrectly marked as English.

**Fix**
The translator endpoint in [src/translate/index.js](/workspaces/nodebb-spring-26-team-f1/src/translate/index.js) was updated to use the Docker host bridge IP: `http://172.17.0.1:5000`.

**Impact**
New non-English posts can now successfully reach the translator service, store translated content correctly, and display the translation button in the UI as intended.