### PR TITLE
Feat: topic translation UI toggle/card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
                 "file-loader": "6.2.0",
                 "fs-extra": "11.3.3",
                 "graceful-fs": "4.2.11",
+                "has-flag": "^4.0.0",
                 "helmet": "7.2.0",
                 "html-to-text": "9.0.5",
                 "imagesloaded": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "file-loader": "6.2.0",
         "fs-extra": "11.3.3",
         "graceful-fs": "4.2.11",
+        "has-flag": "^4.0.0",
         "helmet": "7.2.0",
         "html-to-text": "9.0.5",
         "imagesloaded": "5.0.0",

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -81,14 +81,17 @@ define('forum/topic', [
 
 	function configurePostToggle() {
 		$('.topic').on('click', '.view-translated-btn', function () {
-			// Toggle the visibility of the next .translated-content div
-			$(this).closest('.sensitive-content-message').next('.translated-content').toggle();
-			// Optionally, change the button text based on visibility
-			var isVisible = $(this).closest('.sensitive-content-message').next('.translated-content').is(':visible');
+			const translatedBox = $(this).closest('.sensitive-content-message').next('.translated-message-box');
+			const isVisible = translatedBox.is(':visible');
+			
 			if (isVisible) {
-				$(this).text('Hide the translated message.');
-			} else {
+				// Hide the translated message box
+				translatedBox.fadeOut(250);
 				$(this).text('Click here to view the translated message.');
+			} else {
+				// Show the translated message box
+				translatedBox.fadeIn(250);
+				$(this).text('Hide the translated message.');
 			}
 		});
 	}

--- a/vendor/nodebb-theme-harmony-2.1.35/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.35/templates/partials/topic/post.tpl
@@ -86,8 +86,15 @@
 			<div class="sensitive-content-message">
 			<a class="btn btn-sm btn-primary view-translated-btn">Click here to view the translated message.</a>
 			</div>
-			<div class="translated-content" style="display:none;">
-			{posts.translatedContent}
+			<div class="translated-message-box" style="display:none;">
+				<div class="card mt-2">
+					<div class="card-header">
+						<h6 class="mb-0">Translated Message</h6>
+					</div>
+					<div class="card-body">
+						{posts.translatedContent}
+					</div>
+				</div>
 			</div>
 	        {{{end}}}
 		</div>


### PR DESCRIPTION
This PR improves the topic post translation experience by updating how translated content is displayed and toggled in the client.

**Changes Made**
Updated post translation toggle behavior in topic.js:
Uses the new translated content container selector.
Adds smoother show/hide behavior with fade transitions.
Updates button text based on current visibility state.
Updated translation markup in post.tpl:
Replaced the simple hidden translation block with a structured card-style translated message box.
Kept rendering conditional on posts marked non-English.
Synced dependency metadata in:
package.json
package-lock.json
Added has-flag to keep lockfile and manifest aligned.

**Impact on Existing Behavior**
Existing posts are unaffected unless they already have translation metadata indicating non-English content.
New posts/replies continue to use the existing translation pipeline; when non-English, they now render with the improved toggle/card UI.
No category-specific logic was added, so behavior is consistent across all topic categories.

**Testing Notes**
Verified toggle interaction and button text switching on topic pages.
Verified translated content container renders and hides/shows correctly.
Confirmed branch includes only the four changed files above.